### PR TITLE
Alpine instead of Debian means a smaller/safer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:boron-alpine
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Whoops, mean to add to the commit message:

```
REPOSITORY                                             TAG                   IMAGE ID            CREATED             SIZE
transfigure-alpine                                     latest                50a7510ed761        3 seconds ago       58MB
transfigure                                            latest                6f0ad747759b        7 minutes ago       660MB
```